### PR TITLE
Correct repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ stack haddock --open antenna
 
 1. config/feed.yaml に情報を記載
 2. static/image/logo にアイコンを追加
-3. <https://github.com/lotz84/antenna/compare> よりPull Requestを送って下さい
+3. <https://github.com/haskell-jp/antenna/compare> よりPull Requestを送って下さい
 
 アイコンに関するガイドライン
 ----------------------------

--- a/antenna.cabal
+++ b/antenna.cabal
@@ -63,4 +63,4 @@ test-suite antenna-test
 
 source-repository head
   type:     git
-  location: https://github.com/lotz84/antenna
+  location: https://github.com/haskell-jp/antenna


### PR DESCRIPTION
https://github.com/lotz84/antenna/pull/1 の仕切り直しです。
「forkした」という情報を消せるといいんですけどねぇ 😕 
移行時の修正漏れのようです