### PR TITLE
Add URL to commit message on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ jobs:
         - git config user.name "${GIT_NAME}"
         - git status
         - git add -A
-        - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell"
+        - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
         - git push origin gh-pages


### PR DESCRIPTION
SlackのGitHub integrationでリポジトリーのコミットを通知する際、URLが入っているとすぐに更新内容に飛べて便利だろうと考えたため。