### PR TITLE
Added ilyaletre's hatena blog site

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -58,3 +58,9 @@ sites:
     feed: http://kakkun61.hatenablog.com/feed/category/Haskell
     logo:
       hatena: kakkun61
+  - title: "Hash λ Bye"
+    author: "ilyaletre"
+    url: http://ilyaletre.hatenablog.com/archive/category/Haskell
+    feed: http://ilyaletre.hatenablog.com/feed/category/Haskell
+    logo:
+      hatena: ilyaletre


### PR DESCRIPTION
Haskellカテゴリに絞った私のhatena blogのフィードを追加しました。
基本的にkakkunさんのコピーして直しただけですが、おかしなところあったらコメントください。