### PR TITLE
[WIP] Arukas + Ofelia によるジョブスケジューリング

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: generic
+services:
+  - docker
 cache:
   timeout: 360
   directories:
@@ -27,3 +29,14 @@ jobs:
         - git add -A
         - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
         - git push origin gh-pages
+    - stage: build with docker
+      script:
+        - stack docker pull
+        - stack build --docker
+      after_success:
+        - stack image container --docker
+    - stage: build docker image
+      script: docker build -t "${DOCKER_REPOSITORY}" .
+      after_success:
+        - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+        - docker push "${DOCKER_REPOSITORY}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ jobs:
         - stack build --docker
       after_success:
         - stack image container --docker
-    - stage: build docker image
-      script: docker build -t "${DOCKER_REPOSITORY}" .
-      after_success:
+        - docker build -t "${DOCKER_REPOSITORY}" .
         - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
         - docker push "${DOCKER_REPOSITORY}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcuadros/ofelia AS ofelia
+FROM antenna-bin
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    git \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ofelia /usr/bin/ofelia /usr/bin/ofelia
+COPY ofelia/config.ini /etc/ofelia/
+COPY bin/append-slack-webhook.sh /usr/bin/
+COPY bin/run.sh /usr/bin/
+
+WORKDIR /work
+
+COPY sites.yaml /work/
+
+ENTRYPOINT ["/usr/bin/append-slack-webhook.sh"]
+
+CMD ["/usr/bin/ofelia", "daemon", "--config", "/etc/ofelia/config.ini"]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,15 +12,18 @@ import           Data.Extensible
 import           Data.List          (sortOn)
 import           Data.Maybe         (listToMaybe)
 import qualified Data.Yaml          as Y
+import           GHC.IO.Encoding
 import           ScrapBook          (collect, fetch, toSite, write)
 import qualified ScrapBook
 import           System.Environment (getArgs)
 import           System.FilePath    (dropFileName)
 
 main :: IO ()
-main = (listToMaybe <$> getArgs) >>= \case
-  Nothing   -> error "please input config file path."
-  Just path -> generate path =<< readConfig path
+main = do
+  setLocaleEncoding utf8
+  (listToMaybe <$> getArgs) >>= \case
+    Nothing   -> error "please input config file path."
+    Just path -> generate path =<< readConfig path
 
 readConfig :: FilePath -> IO Config
 readConfig = either (error . show) pure <=< Y.decodeFileEither

--- a/bin/append-slack-webhook.sh
+++ b/bin/append-slack-webhook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "slack-only-on-error = $SLACK_ONLY_ON_ERROR" >> /etc/ofelia/config.ini
+echo "slack-webhook = $SLACK_WEBHOOK" >> /etc/ofelia/config.ini
+exec "$@"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eux
+
+cd /work
+git clone --depth 1 -b gh-pages "https://${GH_TOKEN}@github.com/haskell-jp/antenna.git" temp
+cp sites.yaml temp/sites.yaml
+cd temp
+antenna sites.yaml
+git config user.name "${GIT_NAME}"
+git status
+git add -A
+git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
+git push origin gh-pages
+cd ../
+rm -rfd temp

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -3,6 +3,7 @@
 set -eux
 
 cd /work
+rm -rfd temp
 git clone --depth 1 -b gh-pages "https://${GH_TOKEN}@github.com/haskell-jp/antenna.git" temp
 cp sites.yaml temp/sites.yaml
 cd temp
@@ -12,5 +13,3 @@ git status
 git add -A
 git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
 git push origin gh-pages
-cd ../
-rm -rfd temp

--- a/ofelia/config.ini
+++ b/ofelia/config.ini
@@ -1,0 +1,5 @@
+[job-local "test"]
+schedule = 0 * * * *
+command = /usr/bin/run.sh
+
+[global]

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,11 @@ extra-deps:
   commit: b7cfedba0e34dc117389452b9a61f1e2bbe117fa
 - git: https://github.com/matsubara0507/extensible-instances.git
   commit: a5b543cede63890c84d3f62f9c26349ae9f2e4fc
+
+docker:
+  repo: fpco/stack-build
+  enable: false
+image:
+  container:
+    name: antenna-bin
+    base: fpco/ubuntu-with-libgmp


### PR DESCRIPTION
(これはレビュー用の PR では無く、こういうコトをしたという書き残し用)

現状は Travis CI の daily cron を使ってサイトの更新をしている（antenna バイナリを実行して gh-pages ブランチにコミット）。
このやり方のデメリットは2つ: 
1. daily より短いスパンで更新できない
2. おそらく推奨された Travis CI の使い方ではない

なのでこれを別の方法に移行したい

### Arukas + Ofelia

[Arukas](https://arukas.io/) は Docker コンテナのホスティングサービスで、フリープランだと App を一つだけ利用できる（ @matsubara0507 個人のアカウントのモノを利用）。
[Ofelia](https://github.com/mcuadros/ofelia) は Docker ベースのジョブスケジューラー。

Haskell Antenna の実行バイナリ + Ofelia が入ったイメージを作成し、それを Arukas 上でジョブスケジューリングする。
イメージの更新は Travis CI を利用する。

### 残作業

- [x] 試しにイメージの作成と実行 
    - 暫定的に[個人アカウントに置いた](https://hub.docker.com/r/matsubara0507/antenna/)
- [ ] Arukas にあげて試す
- [ ] haskell-jp/antenna を Docker Hub に作ってイメージを移す（これはできれば）
- [ ] 設定を直す
    - [ ] hourly に変更（今は試すために1minごと）
    - [ ] docker image を push する ci の実行ブランチを master に制限
    - [ ] run.sh が途中で中断されても tmp を削除するように
