### PR TITLE
Scrapbook-0.3 に対応させるためにイロイロバージョンアップ

### DIFF
--- a/app/Antenna/Config.hs
+++ b/app/Antenna/Config.hs
@@ -54,7 +54,6 @@ imagePath config
     hatenaProfileImageLink user =
       mconcat ["https://cdn.profile-image.st-hatena.com/users/", user, "/profile.png"]
 
-
 imagePath' :: Config -> ScrapBook.Site -> Text
 imagePath' config site = fromMaybe (config ^. #blankAvatar) $
   imagePath

--- a/app/Antenna/Config.hs
+++ b/app/Antenna/Config.hs
@@ -6,13 +6,11 @@
 
 module Antenna.Config where
 
-import           Control.Applicative (Alternative (..))
-import           Control.Lens        (view, (&), (.~), (^.))
-import           Data.Default        (def)
+import           RIO
+import qualified RIO.List        as L
+
+import           Data.Default    (def)
 import           Data.Extensible
-import           Data.List           (find)
-import           Data.Maybe          (fromMaybe)
-import           Data.Text           (Text)
 import qualified ScrapBook
 
 type Config = Record
@@ -27,7 +25,7 @@ type Config = Record
 
 toScrapBookConfig :: Config -> ScrapBook.Config
 toScrapBookConfig config =
-  def & #feed .~ Just feedConfig & #sites .~ (shrink <$> config ^. #sites)
+  def & #feed `set` Just feedConfig & #sites `set` (shrink <$> config ^. #sites)
   where
     feedConfig = shrink $ #name @= Just (config ^. #feedName) <: config
 
@@ -58,6 +56,7 @@ imagePath config
 
 
 imagePath' :: Config -> ScrapBook.Site -> Text
-imagePath' config site =
-  fromMaybe (config ^. #blankAvatar) $ imagePath =<< view #logo
-    =<< find ((==) site . ScrapBook.toSite . shrink) (config ^. #sites)
+imagePath' config site = fromMaybe (config ^. #blankAvatar) $
+  imagePath
+    =<< view #logo
+    =<< L.find ((==) site . ScrapBook.toSite . shrink) (config ^. #sites)

--- a/app/Antenna/Html.hs
+++ b/app/Antenna/Html.hs
@@ -3,7 +3,7 @@
 
 module Antenna.Html where
 
-import           RIO                           hiding (div, id, link, span)
+import           RIO                           hiding (div, link, span)
 import           RIO.Directory                 (createDirectoryIfMissing)
 import           RIO.FilePath                  (dropFileName)
 import qualified RIO.Text                      as Text
@@ -14,8 +14,9 @@ import           Antenna.Config
 import qualified ScrapBook
 import           Text.Blaze.Html.Renderer.Text (renderHtml)
 import           Text.Blaze.Html5
-import           Text.Blaze.Html5.Attributes   (class_, height, href, id, lang,
-                                                rel, src, type_, width)
+import           Text.Blaze.Html5.Attributes   (class_, height, href, lang, rel,
+                                                src, type_, width)
+import qualified Text.Blaze.Html5.Attributes   as Attr
 
 data Tab
   = Posts
@@ -50,7 +51,7 @@ writeHtml config path bodyHtml =
         link ! rel "icon" ! type_ "image/png"
              ! href (fromText $ config ^. #favicon)
       body $ div ! class_ "container-md" $ do
-        h1 ! id "header" $ do
+        h1 ! Attr.id "header" $ do
           span $ toHtml (config ^. #title)
           img ! class_ "float-right mt-2" ! height "32"
               ! src (fromText $ config ^. #logo)

--- a/app/Antenna/Html.hs
+++ b/app/Antenna/Html.hs
@@ -57,7 +57,7 @@ writeHtml config path bodyHtml =
               ! src (fromText $ config ^. #logo)
         bodyHtml
 
-postToHtml :: Config -> ScrapBook.Post -> Html
+postToHtml :: Config -> ScrapBook.Post Site -> Html
 postToHtml config post = li ! class_ "d-flex border-bottom py-2" $ do
   span ! class_ "m-2 mr-3" $
     img ! class_ "avatar avatar-small" ! width "32" ! height "32"
@@ -72,7 +72,7 @@ postToHtml config post = li ! class_ "d-flex border-bottom py-2" $ do
         span $ a' ! href (fromText $ site ^. #url) $ toHtml (site ^. #title)
         toHtml $ mconcat [" at ", formatTimeToDate $ Text.unpack (post ^. #date)]
 
-siteToHtml :: Config -> ScrapBook.Site -> Html
+siteToHtml :: Config -> Site -> Html
 siteToHtml config site = li ! class_ "d-flex border-bottom py-2" $ do
   span ! class_ "m-2 mr-3" $
     img ! class_ "avatar avatar-small" ! width "32" ! height "32"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,6 @@ import           Antenna.Html
 import           Control.Monad      ((<=<))
 import           Data.Extensible
 import qualified Data.Yaml          as Y
-import           ScrapBook          (collect, fetch, toSite, write)
 import qualified ScrapBook
 import           System.Environment (getArgs)
 
@@ -43,9 +42,9 @@ generate path config = do
  where
    sconfig = toScrapBookConfig config
    name    = ScrapBook.fileName sconfig feed'
-   sites   = fmap ScrapBook.toSite $ sconfig ^. #sites
+   sites   = fmap toSite $ config ^. #sites
 
-handler :: MonadUnliftIO m => ScrapBook.CollectError -> m [ScrapBook.Post]
+handler :: MonadUnliftIO m => ScrapBook.CollectError -> m [ScrapBook.Post Site]
 handler e = ScrapBook.collect (logError $ displayShow e) >> pure []
 
 feed' :: ScrapBook.Format

--- a/package.yaml
+++ b/package.yaml
@@ -36,5 +36,5 @@ executables:
     - blaze-html
     - data-default
     - extensible
-    - scrapbook
+    - scrapbook >= 0.3
     - yaml

--- a/package.yaml
+++ b/package.yaml
@@ -12,26 +12,29 @@ description:         Please see the README on Github at <https://github.com/hask
 
 dependencies:
 - base >= 4.7 && < 5
+- rio >= 0.1.1.0
 
 ghc-options:
 - -Wall
+- -Wcompat
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
+
+- -threaded
+- -rtsopts
+- -with-rtsopts=-N
+
+default-extensions:
+- NoImplicitPrelude
 
 executables:
   antenna:
     main:                Main.hs
     source-dirs:         app
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
     dependencies:
     - blaze-html
     - data-default
     - extensible
-    - directory
-    - filepath
-    - lens
     - scrapbook
-    - text
-    - time
     - yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.9
+resolver: lts-11.6
 packages:
 - .
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,10 @@
-resolver: lts-11.6
+resolver: lts-12.2
 packages:
 - .
 extra-deps:
 - data-default-instances-text-0.0.1
-- drinkery-0.3
+- drinkery-0.4
 - git: https://github.com/matsubara0507/scrapbook.git
-  commit: 05cb7ac27c0e8364415ee1a76767c0b8f1286569
+  commit: b81ed47a0a7dd13b01f8754fed3687e95aceb6d5
 - git: https://github.com/matsubara0507/extensible-instances.git
   commit: a5b543cede63890c84d3f62f9c26349ae9f2e4fc
-- rio-0.1.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,8 +3,9 @@ packages:
 - .
 extra-deps:
 - data-default-instances-text-0.0.1
-- drinkery-0.1
+- drinkery-0.3
 - git: https://github.com/matsubara0507/scrapbook.git
-  commit: b7cfedba0e34dc117389452b9a61f1e2bbe117fa
+  commit: 2286af3abc98fa71801cea386f4cc38d882ce36d
 - git: https://github.com/matsubara0507/extensible-instances.git
   commit: a5b543cede63890c84d3f62f9c26349ae9f2e4fc
+- rio-0.1.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ extra-deps:
 - data-default-instances-text-0.0.1
 - drinkery-0.3
 - git: https://github.com/matsubara0507/scrapbook.git
-  commit: 2286af3abc98fa71801cea386f4cc38d882ce36d
+  commit: 05cb7ac27c0e8364415ee1a76767c0b8f1286569
 - git: https://github.com/matsubara0507/extensible-instances.git
   commit: a5b543cede63890c84d3f62f9c26349ae9f2e4fc
 - rio-0.1.1.0


### PR DESCRIPTION
大きな変更
- Prelude の代わりに rio パッケージを利用
- レコード多相によって Site 型の情報を多相的に扱う
    - もともとはロゴの情報を線形探索してた
- 一部のサイトがフェッチできなくても全体は落ちないように修正