### PR TITLE
Drone CI で毎時更新をする

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,8 @@ steps:
   - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > /root/.ssh/config
   - cd temp
-  - git config --global user.name "$GIT_NAME"
+  - git config user.name  BOT
+  - git config user.email bot@example.com
   - git status
   - git add -A
   - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
 - name: exec antenna
   image: matsubara0507/antenna
   commands:
-  - git clone -b gh-pages git@github.com/haskell-jp/antenna.git temp
+  - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
   - cp sites.yaml temp/sites.yaml
   - cp -r image/* temp/image
   - cd temp

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,21 +15,18 @@ steps:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > /root/.ssh/config
   - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
   when:
-    branch: drone
+    branch: master
     event:
       exclude: pull_request
 
 - name: exec antenna
   image: haskelljp/antenna
   commands:
+  - mkdir -p temp
   - cp sites.yaml temp/sites.yaml
   - cp -r image/* temp/image
   - cd temp
   - antenna sites.yaml
-  when:
-    branch: drone
-    event:
-      exclude: pull_request
 
 - name: push gh-pages
   image: docker:git
@@ -47,6 +44,6 @@ steps:
   - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
   - git push origin gh-pages
   when:
-    branch: drone
+    branch: master
     event:
       exclude: pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,7 @@ name: default
 clone:
   depth: 5
 
+steps:
 - name: exec antenna
   image: matsubara0507/antenna
   environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,27 +4,20 @@ name: default
 clone:
   depth: 5
 
-steps:
-- name: set deploy key
-  image: docker:git
+- name: exec antenna
+  image: matsubara0507/antenna
   environment:
     GIT_NAME: BOT
     SSH_KEY:
       from_secret: deploy_key
   commands:
-  - git config --global user.name "$GIT_NAME"
   - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
-  when:
-    branch: drone
-
-- name: exec antenna
-  image: matsubara0507/antenna
-  commands:
   - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
   - cp sites.yaml temp/sites.yaml
   - cp -r image/* temp/image
   - cd temp
   - antenna sites.yaml
+  - git config --global user.name "$GIT_NAME"
   - git status
   - git add -A
   - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,7 @@ steps:
       from_secret: deploy_key
   commands:
   - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
+  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > /root/.ssh/config
   - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
   - cp sites.yaml temp/sites.yaml
   - cp -r image/* temp/image

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,8 +5,30 @@ clone:
   depth: 5
 
 steps:
+- name: clone gh-pages
+  image: docker:git
+  environment:
+    SSH_KEY:
+      from_secret: deploy_key
+  commands:
+  - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
+  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > /root/.ssh/config
+  - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
+  when:
+    branch: drone
+
 - name: exec antenna
   image: matsubara0507/antenna
+  commands:
+  - cp sites.yaml temp/sites.yaml
+  - cp -r image/* temp/image
+  - cd temp
+  - antenna sites.yaml
+  when:
+    branch: drone
+
+- name: push gh-pages
+  image: docker:git
   environment:
     GIT_NAME: BOT
     SSH_KEY:
@@ -14,11 +36,7 @@ steps:
   commands:
   - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > /root/.ssh/config
-  - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
-  - cp sites.yaml temp/sites.yaml
-  - cp -r image/* temp/image
   - cd temp
-  - antenna sites.yaml
   - git config --global user.name "$GIT_NAME"
   - git status
   - git add -A

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,9 +15,11 @@ steps:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > /root/.ssh/config
   - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
   when:
-    branch: master
+    branch:
+    - master
     event:
-      exclude: pull_request
+      exclude:
+      - pull_request
 
 - name: exec antenna
   image: haskelljp/antenna
@@ -45,6 +47,8 @@ steps:
   - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
   - git push origin gh-pages
   when:
-    branch: master
+    branch:
+    - master
     event:
-      exclude: pull_request
+      exclude:
+      - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,8 +12,8 @@ steps:
     SSH_KEY:
       from_secret: deploy_key
   commands:
-  - git config --global user.name "${GIT_NAME}"
-  - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chomd 0600 /root/.ssh/id_rsa
+  - git config --global user.name "$GIT_NAME"
+  - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
   when:
     branch: drone
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
       exclude: pull_request
 
 - name: exec antenna
-  image: matsubara0507/antenna
+  image: haskelljp/antenna
   commands:
   - cp sites.yaml temp/sites.yaml
   - cp -r image/* temp/image

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,8 @@ steps:
   - git clone -b gh-pages git@github.com:haskell-jp/antenna.git temp
   when:
     branch: drone
+    event:
+      exclude: pull_request
 
 - name: exec antenna
   image: matsubara0507/antenna
@@ -26,6 +28,8 @@ steps:
   - antenna sites.yaml
   when:
     branch: drone
+    event:
+      exclude: pull_request
 
 - name: push gh-pages
   image: docker:git
@@ -44,3 +48,5 @@ steps:
   - git push origin gh-pages
   when:
     branch: drone
+    event:
+      exclude: pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,19 +5,26 @@ clone:
   depth: 5
 
 steps:
+- name: set deploy key
+  image: docker:git
+  environment:
+    GIT_NAME: BOT
+    SSH_KEY:
+      from_secret: deploy_key
+  commands:
+  - git config --global user.name "${GIT_NAME}"
+  - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chomd 0600 /root/.ssh/id_rsa
+  when:
+    branch: drone
+
 - name: exec antenna
   image: matsubara0507/antenna
-  environment:
-    GH_TOKEN:
-      from_secret: github_api_token
-    GIT_NAME: BOT
   commands:
-  - git clone -b gh-pages "https://${GH_TOKEN}@github.com/haskell-jp/antenna.git" temp
+  - git clone -b gh-pages git@github.com/haskell-jp/antenna.git temp
   - cp sites.yaml temp/sites.yaml
   - cp -r image/* temp/image
   - cd temp
   - antenna sites.yaml
-  - git config user.name "${GIT_NAME}"
   - git status
   - git add -A
   - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,26 @@
+kind: pipeline
+name: default
+
+clone:
+  depth: 5
+
+steps:
+- name: exec antenna
+  image: matsubara0507/antenna
+  environment:
+    GH_TOKEN:
+      from_secret: github_api_token
+    GIT_NAME: BOT
+  commands:
+  - git clone -b gh-pages "https://${GH_TOKEN}@github.com/haskell-jp/antenna.git" temp
+  - cp sites.yaml temp/sites.yaml
+  - cp -r image/* temp/image
+  - cd temp
+  - antenna sites.yaml
+  - git config user.name "${GIT_NAME}"
+  - git status
+  - git add -A
+  - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
+  - git push origin gh-pages
+  when:
+    branch: drone

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
     - stage: build antenna
       script: stack --no-terminal --docker build --bench --no-run-benchmarks --no-haddock-deps --pedantic
     - stage: push docker image
-      if: branch = master
+      if: branch = master AND type = push
       script:
       - stack --docker image container
       - docker tag antenna haskelljp/antenna

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,15 @@ install:
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+- stack docker pull
 jobs:
   include:
     - stage: build dependencies
-      script: stack --no-terminal --install-ghc test --bench --only-dependencies
+      script: stack --no-terminal --docker --install-ghc test --bench --only-dependencies
     - stage: build antenna
-      script: stack --no-terminal build --bench --no-run-benchmarks --no-haddock-deps --pedantic
+      script: stack --no-terminal --docker build --bench --no-run-benchmarks --no-haddock-deps --pedantic
+    - stage: push docker image
+      if: branch = master
+      script:
+       - stack --docker image container
+       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ jobs:
     - stage: push docker image
       if: branch = master
       script:
-       - stack --docker image container
-       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - stack --docker image container
+      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - docker push haskelljp/antenna

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: false
+sudo: required
+services:
+  - docker
 language: generic
 cache:
   timeout: 360
@@ -12,18 +14,7 @@ install:
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 jobs:
   include:
-    - stage: install anttena
-      script: stack --no-terminal install
-    - stage: exec antenna
-      script: git clone -b gh-pages "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" temp
-      if: branch = master AND type IN (push, cron)
-      after_success:
-        - cp sites.yaml temp/sites.yaml
-        - cp -r image/* temp/image
-        - cd temp
-        - stack exec -- antenna sites.yaml
-        - git config user.name "${GIT_NAME}"
-        - git status
-        - git add -A
-        - git diff --quiet && git diff --staged --quiet || git commit -am "[skip ci] Update planet haskell. See https://haskell.jp/antenna/ for new entries!"
-        - git push origin gh-pages
+    - stage: build dependencies
+      script: stack --no-terminal --install-ghc test --bench --only-dependencies
+    - stage: build antenna
+      script: stack --no-terminal build --bench --no-run-benchmarks --no-haddock-deps --pedantic

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,6 @@ jobs:
       if: branch = master
       script:
       - stack --docker image container
+      - docker tag antenna haskelljp/antenna
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker push haskelljp/antenna

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ extra-deps:
 
 docker:
   repo: fpco/stack-build
+  enable: false
 image:
   container:
     name: antenna

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,10 @@ extra-deps:
   commit: b81ed47a0a7dd13b01f8754fed3687e95aceb6d5
 - git: https://github.com/matsubara0507/extensible-instances.git
   commit: a5b543cede63890c84d3f62f9c26349ae9f2e4fc
+
+docker:
+  repo: fpco/stack-build
+image:
+  container:
+    name: antenna
+    base: fpco/ubuntu-with-libgmp


### PR DESCRIPTION
ref #13 

- [x] Stack の Docker integration の設定を追加
    -  今は暫定的に僕の Docker Hub アカウントを使ってます
    - あとで haskell-jp の Docker Hub アカウントを作るつもり
- [x] Drone の設定を追加
    - パーソナルトークンではなく[本リポジトリのデプロイキー](https://github.com/haskell-jp/antenna/settings/keys)をシークレットに設定しています
- [x] Travis CI の方の gh-pages 更新部分を削除
- [x] Docker Hub アカウントを haskell-jp に以降
- [x] Docker イメージを自動ビルド
    - これは TravisCI でやろうと思う
    - Drone Cloud はキャッシュがないので Haskell App のビルドは辛い

Docker image の作成は Travis CI で、gh-pages の更新は Drone でやろうと考えてる。
が、ここの依存関係(Image ができてから gh-pages の更新を実行してほしい)をどうするかな。
毎時更新だし、今回は無視することにする。