### PR TITLE
mod_poppoのブログを追加

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -75,3 +75,9 @@ sites:
         rel: alternate
     logo:
       github: kurokawh
+  - title: "mod_poppoの雑記帳"
+    author: "mod_poppo"
+    url: https://blog.miz-ar.info/category/programming/haskell/
+    feed: https://blog.miz-ar.info/category/programming/haskell/feed/
+    logo:
+      url: https://blog.miz-ar.info/wp-content/uploads/2016/07/cropped-partial-poppo2.png


### PR DESCRIPTION
私 (mod_poppo) のブログを追加していただけると嬉しいです。

「Haskell」カテゴリーの記事だけを含むようにしています。