### PR TITLE
CLI オプションを整理する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+- Refactor: Update LTS to 14.20
+    - update extensible package to 0.7
+- Feat: add cli options: `--versions` `--verbose` `--help`
+- Refactor: use mix.hs
+
 #### 0.2.1
 
 - Refactor: Update LTS to 14.4

--- a/app/GetOpt.hs
+++ b/app/GetOpt.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds  #-}
+
+module GetOpt
+    ( withGetOpt'
+    ) where
+
+import           RIO
+
+import           Data.Extensible
+import           Data.Extensible.GetOpt (OptionDescr, getOptRecord)
+import           System.Environment     (getArgs, getProgName)
+import           System.Exit            (die)
+import           System.IO              (hPutStrLn)
+
+withGetOpt' :: MonadIO m => String -- ^ Non-option usage
+  -> RecordOf (OptionDescr h) xs -- ^ option desciptors
+  -> (RecordOf h xs -> [String] -> String -> m a) -- ^ the result, non-option arguments and usage
+  -> m a
+withGetOpt' nonOptUsage descs k =
+  getOptRecord descs <$> liftIO getArgs >>= \case
+    (r, xs, [],  usage) -> liftIO (mkUsage usage) >>= k r xs
+    (_, _, errs, usage) -> liftIO $ do
+      mapM_ (hPutStrLn stderr) errs
+      mkUsage usage >>= die
+  where
+    mkUsage usage = usage . (++ (' ' : nonOptUsage)) <$> getProgName

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,51 +1,109 @@
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE MultiWayIf        #-}
 {-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds         #-}
+{-# LANGUAGE TypeOperators     #-}
 
 module Main where
 
+import           Paths_antenna          (version)
 import           RIO
-import           RIO.FilePath       (dropFileName)
-import qualified RIO.List           as L
+import           RIO.FilePath           (dropFileName)
+import qualified RIO.List               as L
 
 import           Antenna.Config
 import           Antenna.Html
-import           Control.Monad      ((<=<))
+import           Control.Monad          ((<=<))
 import           Data.Extensible
-import qualified Data.Yaml          as Y
+import           Data.Extensible.GetOpt
+import qualified Data.Yaml              as Y
+import           GetOpt                 (withGetOpt')
+import           Mix
+import           Mix.Plugin.Logger      as MixLogger
 import qualified ScrapBook
-import           System.Environment (getArgs)
+import qualified Version
 
 main :: IO ()
-main = (listToMaybe <$> getArgs) >>= \case
-  Nothing   -> error "please input config file path."
-  Just path -> generate path =<< readConfig path
+main = withGetOpt' "[options] [input-file]" opts $ \r args usage ->
+  if | r ^. #help    -> hPutBuilder stdout (fromString usage)
+     | r ^. #version -> hPutBuilder stdout (Version.build version)
+     | otherwise     -> runCmd r $ listToMaybe args
+  where
+    opts = #help    @= helpOpt
+        <: #version @= versionOpt
+        <: #verbose @= verboseOpt
+        <: nil
+
+type Options = Record
+  '[ "help"    >: Bool
+   , "version" >: Bool
+   , "verbose" >: Bool
+   ]
+
+helpOpt :: OptDescr' Bool
+helpOpt = optFlag ['h'] ["help"] "Show this help text"
+
+versionOpt :: OptDescr' Bool
+versionOpt = optFlag [] ["version"] "Show version"
+
+verboseOpt :: OptDescr' Bool
+verboseOpt = optFlag ['v'] ["verbose"] "Enable verbose mode: verbosity level \"debug\""
+
+type Env = Record
+  '[ "logger" >: LogFunc
+   , "config" >: Config
+   ]
+
+runCmd :: Options -> Maybe FilePath -> IO ()
+runCmd _ Nothing        = error "please input config file path."
+runCmd opts (Just path) = do
+  config <- readConfig path
+  let plugin = hsequence
+             $ #logger <@=> MixLogger.buildPlugin logOpts
+            <: #config <@=> pure config
+            <: nil
+  Mix.run plugin $ generate path
+  where
+    logOpts = #handle @= stdout
+           <: #verbose @= (opts ^. #verbose)
+           <: nil
 
 readConfig :: FilePath -> IO Config
 readConfig = either (error . show) pure <=< Y.decodeFileEither
 
-generate :: FilePath -> Config -> IO ()
-generate path config = do
-  posts <- fmap concat . forM sites $ \site ->
-    ScrapBook.collect (ScrapBook.fetch site) `catch` handler
+generate :: FilePath -> RIO Env ()
+generate path = do
+  config <- asks (view #config)
+  let sites = fmap toSite $ config ^. #sites
+  MixLogger.logDebug $ "collect posts with: " <> fromString path
+  posts <- fmap concat $
+    runCollector (forM sites $ \site -> ScrapBook.fetch site `catch` handler)
 
-  writeFeed (dropFileName path ++ name)
-      =<< ScrapBook.collect (ScrapBook.write sconfig feed' posts)
+  let sconfig  = toScrapBookConfig config
+      feedName = dropFileName path <> ScrapBook.fileName sconfig feed'
+  MixLogger.logDebug $ "write feed to: " <> fromString feedName
+  writeFeed feedName =<< ScrapBook.collect (ScrapBook.write sconfig feed' posts)
 
+  MixLogger.logDebug "write index.html"
   writeHtml config "./index.html" $ tabNav (config ^. #baseUrl) Posts $ mapM_
     (postToHtml config)
     (take 50 . reverse $ L.sortOn (view #date) posts)
 
+  MixLogger.logDebug "write sites.html"
   writeHtml config "./sites.html" $ tabNav (config ^. #baseUrl) Sites $ mapM_
     (siteToHtml config)
     (L.sortOn (view #title) sites)
- where
-   sconfig = toScrapBookConfig config
-   name    = ScrapBook.fileName sconfig feed'
-   sites   = fmap toSite $ config ^. #sites
 
-handler :: MonadUnliftIO m => ScrapBook.CollectError -> m [ScrapBook.Post Site]
-handler e = ScrapBook.collect (logError $ displayShow e) >> pure []
+runCollector :: ScrapBook.Collecter a -> RIO Env a
+runCollector act = do
+  logger <- asks (view #logger)
+  runRIO (ScrapBook.Env logger) act
+
+handler ::
+  (MonadIO m, MonadReader env m, HasLogFunc env)
+  => ScrapBook.CollectError -> m [ScrapBook.Post Site]
+handler e = MixLogger.logError (displayShow e) >> pure []
 
 feed' :: ScrapBook.Format
 feed' = embedAssoc $ #feed @= ()

--- a/app/Version.hs
+++ b/app/Version.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE TemplateHaskell  #-}
+
+module Version
+  ( build
+  ) where
+
+import           RIO
+
+import           Data.Version (Version)
+import qualified Data.Version as Version
+import qualified GitHash
+
+build :: Version -> Builder
+build v = toBuilder $ unwords
+  [ "Version"
+  , Version.showVersion v ++ ","
+  , "Git revision"
+  , GitHash.giCommitDate gi
+  , "(" ++ show (GitHash.giCommitCount gi) ++ " commits)"
+  ]
+  where
+    gi = $$(GitHash.tGitInfoCwd)
+
+toBuilder :: String -> Builder
+toBuilder = encodeUtf8Builder . fromString

--- a/package.yaml
+++ b/package.yaml
@@ -31,5 +31,7 @@ executables:
     dependencies:
     - blaze-html
     - extensible >= 0.6
+    - githash
+    - mix
     - scrapbook-core >= 0.4
     - yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,18 @@
-resolver: lts-14.4
+resolver: lts-14.20
 packages:
 - .
 extra-deps:
 - drinkery-0.4
-- extensible-0.6.1
+- extensible-0.7
 - membership-0
 - git: https://github.com/matsubara0507/scrapbook.git
   commit: 9ed6874c12ce53b99569a9952253e89859148cf5
   subdirs:
   - lib/scrapbook-core
+- github: matsubara0507/mix.hs
+  commit: 4978a33dec736799b30c14e215f7fa0f29fa2884
+  subdirs:
+  - mix
 
 docker:
   repo: matsubara0507/stack-build

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,12 +12,12 @@ packages:
   original:
     hackage: drinkery-0.4
 - completed:
-    hackage: extensible-0.6.1@sha256:d73a5dc13bd00f44ace729f83ce868e81a45ea31c7453a6f8a4a9b5b0591d600,2860
+    hackage: extensible-0.7@sha256:12dfa21548aba9f3b02a2f708a935240bae43383945f41e4e9054f37e421035b,2859
     pantry-tree:
-      size: 2354
-      sha256: 9fadd24af89df601f19d57893b513d1742a1942670d6d2e73e79fb4b7aabce65
+      size: 2149
+      sha256: 732d4bf93a15cbbbaa344ae3ee1e2bdbfa12b0c90df9595c18d543da9d29a33c
   original:
-    hackage: extensible-0.6.1
+    hackage: extensible-0.7
 - completed:
     hackage: membership-0@sha256:3a11d8fd53cb1a76bb9273e6c929bbf9d649f109714bf487abb3143be04ddc81,995
     pantry-tree:
@@ -41,9 +41,25 @@ packages:
     subdir: lib/scrapbook-core
     git: https://github.com/matsubara0507/scrapbook.git
     commit: 9ed6874c12ce53b99569a9952253e89859148cf5
+- completed:
+    size: 8280
+    subdir: mix
+    url: https://github.com/matsubara0507/mix.hs/archive/4978a33dec736799b30c14e215f7fa0f29fa2884.tar.gz
+    cabal-file:
+      size: 1110
+      sha256: 946df4a87070784d7ea659f6a3ad2f346f8cf31fea1135fc342feb5a303fa147
+    name: mix
+    version: 0.1.1
+    sha256: 200ad779113f600d351be1e696d419f4332073dfbe76e5a666b82e17cb7e16d5
+    pantry-tree:
+      size: 598
+      sha256: 689bed307dc233a6c50e01f00295a079dc40a4291700646f3ca423d714ba35fc
+  original:
+    subdir: mix
+    url: https://github.com/matsubara0507/mix.hs/archive/4978a33dec736799b30c14e215f7fa0f29fa2884.tar.gz
 snapshots:
 - completed:
-    size: 523884
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/4.yaml
-    sha256: 16f24be248b42c9e16d59db84378836b1e7c239448a041cae46d32daffa45a8b
-  original: lts-14.4
+    size: 524154
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/20.yaml
+    sha256: 2f5099f69ddb6abfe64400fe1e6a604e8e628f55e6837211cd70a81eb0a8fa4d
+  original: lts-14.20


### PR DESCRIPTION
`--versions` `--verbose` `--help` の基本的な3つを追加した。

ついでに:

- LTS のバージョンを 14.20 にした
- extensible のバージョンを 0.7 にした
- [mix.hs](https://github.com/matsubara0507/mix.hs) を使ってリファクタリング
- デバッグログを追加

オプションなしで実行した時の動作は変わらないはず。
