### PR TITLE
HTML生成以外の処理を制御する CLI オプションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
     - update extensible package to 0.7
 - Feat: add cli options: `--versions` `--verbose` `--help`
 - Refactor: use mix.hs
+- Feat: advanced cli options
+    - `--with-copy` : copy files by another branch
+    - `--skip` : skip generate HTML
+    - `--with-commit` : create commit with changed files
+    - `--with-push` : push commit
+    - add these settings to config file
 
 #### 0.2.1
 

--- a/app/Antenna/Config.hs
+++ b/app/Antenna/Config.hs
@@ -19,6 +19,7 @@ type Config = Record
    , "logo"        >: Text
    , "favicon"     >: Text
    , "sites"       >: [SiteConfig]
+   , "git"         >: Maybe GitConfig
    ]
 
 toSite :: SiteConfig -> Site
@@ -65,3 +66,17 @@ imagePath config
 imagePath' :: Config -> Site -> Text
 imagePath' config site =
   fromMaybe (config ^. #blankAvatar) $ imagePath =<< (site ^. #logo)
+
+type GitConfig = Record
+  '[ "branch" >: Text
+   , "files"  >: [Text]
+   ]
+
+defaultGitConfig :: GitConfig
+defaultGitConfig
+    = #branch @= "gh-pages"
+   <: #files  @= []
+   <: nil
+
+gitConfig :: Config -> GitConfig
+gitConfig = fromMaybe defaultGitConfig . view #git

--- a/app/Antenna/Config.hs
+++ b/app/Antenna/Config.hs
@@ -7,6 +7,7 @@
 module Antenna.Config where
 
 import           RIO
+import qualified RIO.Text        as T
 
 import           Data.Extensible
 import qualified ScrapBook
@@ -70,13 +71,20 @@ imagePath' config site =
 type GitConfig = Record
   '[ "branch" >: Text
    , "files"  >: [Text]
+   , "copy"   >: [Text] -- `branch:path` list
    ]
 
 defaultGitConfig :: GitConfig
 defaultGitConfig
     = #branch @= "gh-pages"
    <: #files  @= []
+   <: #copy   @= []
    <: nil
 
 gitConfig :: Config -> GitConfig
 gitConfig = fromMaybe defaultGitConfig . view #git
+
+splitCopyTarget :: Text -> (Text, Text)
+splitCopyTarget target = case T.split (== ':') target of
+  [branch, path] -> (branch, path)
+  _              -> (target, "")

--- a/app/Git.hs
+++ b/app/Git.hs
@@ -7,6 +7,9 @@ import qualified RIO.Text as Text
 
 import           Shelly   hiding (FilePath, unlessM)
 
+checkout :: [Text] -> Sh ()
+checkout = command1_ "git" [] "checkout"
+
 pull :: [Text] -> Sh ()
 pull = command1_ "git" [] "pull"
 

--- a/app/Git.hs
+++ b/app/Git.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Git where
+
+import           RIO
+import qualified RIO.Text as Text
+
+import           Shelly   hiding (FilePath, unlessM)
+
+pull :: [Text] -> Sh ()
+pull = command1_ "git" [] "pull"
+
+push :: [Text] -> Sh ()
+push = command1_ "git" [] "push"
+
+commit :: [Text] -> Sh ()
+commit = command1_ "git" [] "commit"
+
+add :: [Text] -> Sh ()
+add = command1_ "git" [] "add"
+
+diffFileNames :: [Text] -> Sh [Text]
+diffFileNames opts = Text.lines <$> command1 "git" [] "diff" ("--name-only" : opts)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -129,6 +129,7 @@ feed' = embedAssoc $ #feed @= ()
 commitGeneratedFiles :: RIO Env ()
 commitGeneratedFiles = do
   files <- view #files <$> asks (gitConfig . view #config)
+  MixLogger.logDebug $ "create commit with " <> displayShow files
   MixShell.exec $ do
     Git.add files
     changes <- Git.diffFileNames ["--staged"]
@@ -139,4 +140,5 @@ commitGeneratedFiles = do
 pushCommit :: RIO Env ()
 pushCommit = do
   branch <- view #branch <$> asks (gitConfig . view #config)
+  MixLogger.logDebug $ "push commit to origin/" <> display branch
   MixShell.exec (Git.push ["origin", branch])

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -73,6 +73,7 @@ runCmd opts (Just path) = do
             <: #work   <@=> pure "."
             <: nil
   Mix.run plugin $ do
+    when (opts ^. #withCommit) $ MixShell.exec (Git.pull [])
     paths <- generate path
     when (opts ^. #withCommit) $ commitGeneratedFiles paths
   where

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -36,6 +36,7 @@ main = withGetOpt' "[options] [input-file]" opts $ \r args usage ->
         <: #version    @= versionOpt
         <: #verbose    @= verboseOpt
         <: #withCommit @= withCommitOpt
+        <: #withPush   @= withPushOpt
         <: nil
 
 type Options = Record
@@ -43,6 +44,7 @@ type Options = Record
    , "version"    >: Bool
    , "verbose"    >: Bool
    , "withCommit" >: Bool
+   , "withPush"   >: Bool
    ]
 
 helpOpt :: OptDescr' Bool
@@ -56,6 +58,9 @@ verboseOpt = optFlag ['v'] ["verbose"] "Enable verbose mode: verbosity level \"d
 
 withCommitOpt :: OptDescr' Bool
 withCommitOpt = optFlag [] ["with-commit"] "Create commit after generate files"
+
+withPushOpt :: OptDescr' Bool
+withPushOpt = optFlag [] ["with-push"] "Push commit after create commit"
 
 type Env = Record
   '[ "logger" >: LogFunc
@@ -76,6 +81,7 @@ runCmd opts (Just path) = do
     when (opts ^. #withCommit) $ MixShell.exec (Git.pull [])
     paths <- generate path
     when (opts ^. #withCommit) $ commitGeneratedFiles paths
+    when (opts ^. #withPush) $ MixShell.exec (Git.push [])
   where
     logOpts = #handle @= stdout
            <: #verbose @= (opts ^. #verbose)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -30,13 +30,13 @@ main :: IO ()
 main = withGetOpt' "[options] [input-file]" opts $ \r args usage ->
   if | r ^. #help    -> hPutBuilder stdout (fromString usage)
      | r ^. #version -> hPutBuilder stdout (Version.build version)
-     | otherwise     -> runCmd r $ listToMaybe args
+     | otherwise     -> runCmd r (listToMaybe args)
   where
     opts = #help       @= helpOpt
         <: #version    @= versionOpt
         <: #verbose    @= verboseOpt
-        <: #withCopy   @= withCopyOpt
         <: #skip       @= skipOpt
+        <: #withCopy   @= withCopyOpt
         <: #withCommit @= withCommitOpt
         <: #withPush   @= withPushOpt
         <: nil
@@ -45,8 +45,8 @@ type Options = Record
   '[ "help"       >: Bool
    , "version"    >: Bool
    , "verbose"    >: Bool
-   , "withCopy"   >: Bool
    , "skip"       >: Bool
+   , "withCopy"   >: Bool
    , "withCommit" >: Bool
    , "withPush"   >: Bool
    ]
@@ -60,11 +60,11 @@ versionOpt = optFlag [] ["version"] "Show version"
 verboseOpt :: OptDescr' Bool
 verboseOpt = optFlag ['v'] ["verbose"] "Enable verbose mode: verbosity level \"debug\""
 
-withCopyOpt :: OptDescr' Bool
-withCopyOpt = optFlag [] ["with-copy"] "Copy files by another branch before generate HTML"
-
 skipOpt :: OptDescr' Bool
 skipOpt = optFlag [] ["skip"] "Skip generate HTML"
+
+withCopyOpt :: OptDescr' Bool
+withCopyOpt = optFlag [] ["with-copy"] "Copy files by another branch before generate HTML"
 
 withCommitOpt :: OptDescr' Bool
 withCommitOpt = optFlag [] ["with-commit"] "Create commit after generate HTML"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -36,6 +36,7 @@ main = withGetOpt' "[options] [input-file]" opts $ \r args usage ->
         <: #version    @= versionOpt
         <: #verbose    @= verboseOpt
         <: #withCopy   @= withCopyOpt
+        <: #skip       @= skipOpt
         <: #withCommit @= withCommitOpt
         <: #withPush   @= withPushOpt
         <: nil
@@ -45,6 +46,7 @@ type Options = Record
    , "version"    >: Bool
    , "verbose"    >: Bool
    , "withCopy"   >: Bool
+   , "skip"       >: Bool
    , "withCommit" >: Bool
    , "withPush"   >: Bool
    ]
@@ -60,6 +62,9 @@ verboseOpt = optFlag ['v'] ["verbose"] "Enable verbose mode: verbosity level \"d
 
 withCopyOpt :: OptDescr' Bool
 withCopyOpt = optFlag [] ["with-copy"] "Copy files by another branch before generate HTML"
+
+skipOpt :: OptDescr' Bool
+skipOpt = optFlag [] ["skip"] "Skip generate HTML"
 
 withCommitOpt :: OptDescr' Bool
 withCommitOpt = optFlag [] ["with-commit"] "Create commit after generate HTML"
@@ -85,7 +90,7 @@ runCmd opts (Just path) = do
   Mix.run plugin $ do
     when (opts ^. #withCommit) $ MixShell.exec (Git.pull [])
     when (opts ^. #withCopy)   $ copyFilesByAnotherBranch
-    generate path
+    when (not $ opts ^. #skip) $ generate path
     when (opts ^. #withCommit) $ commitGeneratedFiles
     when (opts ^. #withPush)   $ pushCommit
   where

--- a/package.yaml
+++ b/package.yaml
@@ -33,5 +33,7 @@ executables:
     - extensible >= 0.6
     - githash
     - mix
+    - mix-plugin-shell
     - scrapbook-core >= 0.4
+    - shelly
     - yaml

--- a/sites.yaml
+++ b/sites.yaml
@@ -4,6 +4,9 @@ feedName: feed.xml
 blankAvatar: ./image/logo/blank-avatar.png
 logo: https://haskell.jp/img/logo.svg
 favicon: https://haskell.jp/img/favicon.png
+git:
+  branch: gh-pages
+  files: ["index.html", "sites.html", "fees.xml"]
 
 sites:
   - title: "Haskellタグが付けられた新着投稿 - Qiita"

--- a/sites.yaml
+++ b/sites.yaml
@@ -6,7 +6,15 @@ logo: https://haskell.jp/img/logo.svg
 favicon: https://haskell.jp/img/favicon.png
 git:
   branch: gh-pages
-  files: ["index.html", "sites.html", "fees.xml"]
+  files:
+    - sites.yaml
+    - image
+    - index.html
+    - sites.html
+    - feed.xml
+  copy:
+    - master:sites.yaml
+    - master:image
 
 sites:
   - title: "Haskellタグが付けられた新着投稿 - Qiita"

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ extra-deps:
   commit: 4978a33dec736799b30c14e215f7fa0f29fa2884
   subdirs:
   - mix
+  - mix-plugin-shell
 
 docker:
   repo: matsubara0507/stack-build

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -57,6 +57,22 @@ packages:
   original:
     subdir: mix
     url: https://github.com/matsubara0507/mix.hs/archive/4978a33dec736799b30c14e215f7fa0f29fa2884.tar.gz
+- completed:
+    size: 8280
+    subdir: mix-plugin-shell
+    url: https://github.com/matsubara0507/mix.hs/archive/4978a33dec736799b30c14e215f7fa0f29fa2884.tar.gz
+    cabal-file:
+      size: 1083
+      sha256: ddac0c273cf85cc2629c9bf4cc9a952805e146d601b71324468dcb4ad5aaff95
+    name: mix-plugin-shell
+    version: 0.1.0
+    sha256: 200ad779113f600d351be1e696d419f4332073dfbe76e5a666b82e17cb7e16d5
+    pantry-tree:
+      size: 383
+      sha256: 7bbce9d5ea01f6432cecf3151b7c93751d508c0b28444436365eebda58f599d8
+  original:
+    subdir: mix-plugin-shell
+    url: https://github.com/matsubara0507/mix.hs/archive/4978a33dec736799b30c14e215f7fa0f29fa2884.tar.gz
 snapshots:
 - completed:
     size: 524154


### PR DESCRIPTION
以下4つ:
- `--skip` : HTMLの生成をスキップする
- `--with-copy` : 設定したファイルを別ブランチからコピーしてくる
- `--with-commit` : 設定したファイルの差分がある場合をコミットを作成する
- `--with-push` : 設定したブランチへプッシュする

設定は全て設定ファイル(sites.yaml)の `git:` 以下。

ちなみに、下記のように実行することで DroneCI で行なっている gh-pages の更新を再現できる:

```
// なお、このリポジトリへの push 権限はある前提
$ antenna --skip --with-copy sites.yaml
$ antenna --with-commit --with-push sites.yaml
```

(設定ファイル自体もコピーしてくるので、どうしても2回実行する必要がある)