### PR TITLE
actions/setup-haskell の代わりに haskell/actions/setup を使う

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         "
         restore-keys: |
           ${{ runner.os }}-stack-
-    - uses: haskell/actions/setup@main
+    - uses: haskell/actions/setup@v1.1.7
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         "
         restore-keys: |
           ${{ runner.os }}-stack-
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@main
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -36,7 +36,7 @@ jobs:
         "
         restore-keys: |
           ${{ runner.os }}-stack-
-    - uses: haskell/actions/setup@main
+    - uses: haskell/actions/setup@v1.1.7
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -36,7 +36,7 @@ jobs:
         "
         restore-keys: |
           ${{ runner.os }}-stack-
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@main
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
なんと https://github.com/actions/setup-haskell がアーカイブされていた（[メンテナンスする人がいなくなったらしい](https://github.com/actions/setup-haskell/pull/56)）。

代わりに、https://github.com/haskell/actions/tree/main/setup へ移したっぽいので antenna のアクションも移行する。