### PR TITLE
Update to Ubuntu 22.04 on GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.os }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   update:
     name: ${{ matrix.os }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
下記のようなメールがGitHubから届いたので更新します。通知のために一応レビュワーを設定しましたが、ビルドが通り次第マージします。

Subject: "[Action Required] Ubuntu-20.04 hosted runner image is closing down"

> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
>
>    March 4 14:00 UTC – 22:00 UTC
>    March 11 13:00 UTC – 21:00 UTC
>    March 18 13:00 UTC – 21:00 UTC
>    March 25 13:00 UTC – 21:00 UTC
>
> What you need to do
>
> Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=1befe7689f3c4a1a9cba67758d7c6fa0&elq=9c496fd586294edc84daf9db42f80757&elqaid=4309&elqat=1&elqak=8AF512931A9D3060F4A93E1FC36635281ABFB3E6AB302192E9D7FC2B6B9BC0F0CC88). Please contact GitHub [Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=51ced43500f64a46924167a4a536829b&elq=9c496fd586294edc84daf9db42f80757&elqaid=4309&elqat=1&elqak=8AF5D818E42E3357A6143F29D23F7AD3B3C1B3E6AB302192E9D7FC2B6B9BC0F0CC88) if you run into any problems or need help.